### PR TITLE
moved a debug line to where it works

### DIFF
--- a/examples/basics/visuals/line_draw.py
+++ b/examples/basics/visuals/line_draw.py
@@ -93,7 +93,6 @@ class EditLineVisual(scene.visuals.Line):
                               size=size, face_color=self.marker_colors)
 
     def on_mouse_press(self, pos_scene):
-        # self.print_mouse_event(event, 'Mouse press')
         # pos_scene = event.pos[:3]
 
         # find closest point to mouse and select it
@@ -168,6 +167,8 @@ class Canvas(scene.SceneCanvas):
         self.freeze()
 
     def on_mouse_press(self, event):
+        # self.line.print_mouse_event(event, 'Mouse press')
+
         tr = self.scene.node_transform(self.line)
         pos = tr.map(event.pos)
         self.line.on_mouse_press(pos)


### PR DESCRIPTION
Moved line 96 into the Canvas class (on_mouse_press method) so it can now see the event object.

The next line
    # pos_scene = event.pos[:3]
would also fail if uncommented but as it changes the pos_scene variable it is not so straightforward to fix unless event is also sent to the method, changing the API.